### PR TITLE
Fix keyword indexing: use publication id instead of submission id

### DIFF
--- a/classes/SolrWebService.inc.php
+++ b/classes/SolrWebService.inc.php
@@ -215,7 +215,6 @@ class SolrWebService {
 	 */
 	function _indexingTransaction($sendXmlCallback, $batchSize = SOLR_INDEXING_MAX_BATCHSIZE, $journalId = null) {
 		$journalSettingsDao = DAORegistry::getDAO('JournalSettingsDAO');
-
 		$submissionArray = [];
 		$submissionsIterator = Services::get('submission')->getMany(['contextId' => $journalId , 'status' => STATUS_PUBLISHED]);
 		$submissionDao = DAORegistry::getDAO('SubmissionDAO');
@@ -465,7 +464,7 @@ class SolrWebService {
 
 		// Add disciplines.
 		$submissionDisciplineDao = DAORegistry::getDAO('SubmissionDisciplineDAO');
-		$disciplines = $submissionDisciplineDao->getDisciplines($article->getId(), $supportedLocales);
+		$disciplines = $submissionDisciplineDao->getDisciplines($article->getData('currentPublicationId'), $supportedLocales);
 
 		foreach ($disciplines as $locale => $discipline) {
 			if (empty($discipline)) {
@@ -491,7 +490,7 @@ class SolrWebService {
 		}
 
 		$submissionSubjectDao = DAORegistry::getDAO('SubmissionSubjectDAO');
-		$subjects = $submissionSubjectDao->getSubjects($article->getId(), $supportedLocales);
+		$subjects = $submissionSubjectDao->getSubjects($article->getData('currentPublicationId'), $supportedLocales);
 		foreach ($subjects as $locale => $subject) {
 			if (empty($subject)) {
 				unset($subjects[$locale]);
@@ -501,7 +500,7 @@ class SolrWebService {
 		// in OJS2, keywords and subjects where put together into the subject Facet.
 		// For now, I do the same here. TODO: Decide if this is wanted.
 		$submissionKeywordDAO = DAORegistry::getDAO('SubmissionKeywordDAO');
-		$keywords = $submissionKeywordDAO->getKeywords($article->getId(), $supportedLocales);
+		$keywords = $submissionKeywordDAO->getKeywords($article->getData('currentPublicationId'), $supportedLocales);
 		foreach($keywords as $locale => $keyword) {
 			if (empty($keyword)) {
 				unset($keywords[$locale]);

--- a/tools/fetchArticle.php
+++ b/tools/fetchArticle.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @file tools/fetchLuceneArticle.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
+ *
+ * @class fetchLuceneArticleTool
+ * @ingroup plugins_generic_lucene
+ *
+ * @brief CLI tool to fetch a Lucene document for an article
+ */
+
+require(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/tools/bootstrap.inc.php');
+
+import('plugins.generic.lucene.LucenePlugin');
+import('plugins.generic.lucene.classes.SolrWebService');
+import('plugins.generic.lucene.classes.EmbeddedServer');
+
+class fetchLuceneArticleTool extends CommandLineTool {
+
+	/**
+	 * Constructor.
+	 * @param $argv array command-line arguments
+	 */
+	function __construct($argv = array()) {
+		parent::__construct($argv);
+
+		if (!sizeof($this->argv)) {
+			$this->usage();
+			exit(1);
+		}
+
+		$this->parameters = $this->argv;
+	}
+
+	/**
+	 * Print command usage information.
+	 */
+	function usage() {
+		echo _('plugins.generic.lucene.fetchLuceneDoc') . "\n"
+			. "Usage:\n"
+			. "{$this->scriptName} submission submission_id [...]\n";
+	}
+
+	/**
+	 * Check citations DOIs
+	 */
+	function execute() {
+		$submissionDao = DAORegistry::getDAO('SubmissionDAO');
+		$contextDao = Application::getContextDAO();
+
+		switch(array_shift($this->parameters)) {
+			case 'submission':
+				foreach($this->parameters as $submissionId) {
+					$submission = $submissionDao->getById($submissionId);
+					if(!isset($submission)) {
+						printf("Error: Skipping $submissionId. Unknown submission.\n");
+						continue;
+					}
+					$plugin = PluginRegistry::loadPlugin('generic', 'lucene');
+					$solrWebService = $plugin->getSolrWebService();
+					$doc = $solrWebService->getArticleFromIndex($submissionId);
+					var_dump($doc);
+				}
+				break;
+			default:
+				$this->usage();
+				break;
+		}
+	}
+}
+
+$tool = new fetchLuceneArticleTool(isset($argv) ? $argv : array());
+$tool->execute();


### PR DESCRIPTION
Keyword facets did not work properly on our Lucene/Solr installations. Inspection of the Solr/Lucene index showed that keywords field and facet was missing for many articles that had keywords. This is due to the fact that the submission Id instead of the publication Id was used to extract the keywords from the OJS database. 

