### PR TITLE
Fix: restrict plugin management to site level when enabled globally

### DIFF
--- a/LucenePlugin.php
+++ b/LucenePlugin.php
@@ -1265,4 +1265,10 @@ class LucenePlugin extends GenericPlugin {
 			4 => __('plugins.generic.lucene.sectionForm.ranking.high')
 		];
 	}
+	function getCanDisable() {
+    if ($this->getCurrentContextId() != \PKPApplication::CONTEXT_SITE && $this->getSetting(\PKPApplication::CONTEXT_SITE, 'enabled')) {
+        return false;
+    }
+    return true;
+	}
 }


### PR DESCRIPTION
### Summary
This PR prevents the Lucene plugin from being disabled at the journal level if it has been enabled globally by the Site Administrator.

### The Problem
In multi-journal OJS installations, the Lucene plugin currently lacks independence between journals. I've observed that if a single Journal Manager disables the plugin, it is effectively disabled for **all other journals** on the site simultaneously. 

This behavior is critical because:
1. One journal's action can break the search functionality for the entire institution.
2. It makes it impossible to maintain a stable, centralized search infrastructure.

### The Solution
Following the logic used in the `openId` plugin, I implemented the `getCanDisable()` method. This ensures that:
- The **Site Administrator** retains full control to enable/disable the plugin globally.
- **Journal Managers** cannot disable the plugin if it's active at the site level (the checkbox appears grayed out).

### Testing
- Verified that disabling the plugin in one journal no longer affects others because the option is now locked for Journal Managers.
- Verified that the UI correctly reflects the "locked" state when the Site Admin has enabled the plugin.